### PR TITLE
Fix for max streak calculation

### DIFF
--- a/src/func.tsx
+++ b/src/func.tsx
@@ -6,7 +6,13 @@ export const handleResponse = (res: Response): Response => {
 export const sum = (a: number, b: number) => a + b
 
 export const findLongestStreak = (days: number[]): number => {
-    const x = days.slice().sort().reduce((a, c) => {
+    if (days.length === 0) return 0;
+    const x = days.slice().sort((a, b) => a - b).reduce((a, c, index) => {
+        if (index === 0) {
+            a.prev = c;
+            return a;
+        }
+
         const streak = a.prev + 1 === c;
         if (streak) {
             a.streaks[a.streaks.length - 1]++


### PR DESCRIPTION
Due to incorrect sorting by default, the streak was calculated incorrectly, you can check it on the user data "suzrik". Debug data in the original code:

days:
1,2,3,4,5,6,9,11,12,17,18,21,25,28,31,36,64,65,66,67,71,79,84,86,87,88,89,91,92,94

x.streaks:
2,2,2,1,1,1,1,1,1,1,3,4,1,1,1,4,1,2,1